### PR TITLE
CLOSES #41: Set PHP session save handler and path from environment

### DIFF
--- a/etc/php.d/50-php.ini
+++ b/etc/php.d/50-php.ini
@@ -28,8 +28,8 @@ date.timezone = "${PHP_OPTIONS_DATE_TIMEZONE:-UTC}"
 mysqli.reconnect = On
 
 [Session]
-session.save_handler = files
-session.save_path = "${APACHE_CONTENT_ROOT:-/var/www/app}/var/session"
+session.save_handler = "${PHP_OPTIONS_SESSION_SAVE_HANDLER:-files}"
+session.save_path = "${PHP_OPTIONS_SESSION_SAVE_PATH:-/var/lib/php/session}"
 session.name = app-session
 session.cookie_httponly = 1
 session.hash_function = sha512


### PR DESCRIPTION
Resolves #41 

- Adds configuration of PHP session save handler and path from environment variables `PHP_OPTIONS_SESSION_SAVE_HANDLER` and `PHP_OPTIONS_SESSION_SAVE_PATH` respectively.