### PR TITLE
CLOSES #45: Adds setting session name via PHP_OPTIONS_SESSION_NAME.

### DIFF
--- a/etc/php.d/50-php.ini
+++ b/etc/php.d/50-php.ini
@@ -30,7 +30,7 @@ mysqli.reconnect = On
 [Session]
 session.save_handler = "${PHP_OPTIONS_SESSION_SAVE_HANDLER:-files}"
 session.save_path = "${PHP_OPTIONS_SESSION_SAVE_PATH:-/var/lib/php/session}"
-session.name = app-session
+session.name = "${PHP_OPTIONS_SESSION_NAME:-PHPSESSID}"
 session.cookie_httponly = 1
 session.hash_function = sha512
 session.hash_bits_per_character = 5


### PR DESCRIPTION
Resolves #45 

- Adds support for setting PHP session name via the `PHP_OPTIONS_SESSION_NAME` environment variable.